### PR TITLE
dd/SWMAAS-1217-map-initialize-location-for-two-samples

### DIFF
--- a/Samples/README.md
+++ b/Samples/README.md
@@ -14,7 +14,9 @@ In order to see these use cases in action, you will need to set up the sample to
 
 2. There is also a string resource for `google_maps_key` in the `strings.xml` folder. If you need help getting a Google Maps API Key,  please find instructions [here](https://developers.google.com/maps/documentation/android-sdk/start#step_4_get_a_google_maps_api_key).
 
-3. Lastly, you will need to retrieve your `buildingId` from the MaaS portal. to do this, you'll need to navigate to the Mapping section and open the settings for your building. This can be done by drilling down the menu to the building level (Venue-->Campus-->Building). Hover your mouse over the desired building and click the gear icon to see your building configuration. Once you have your `buildingId`, add it to `integers.xml` to point the sample at your building.
+3. You will also need to retrieve your buildingId from the MaaS portal. to do this, you'll need to navigate to the Mapping section and open the settings for your building. This can be done by drilling down the menu to the building level (Venue-->Campus-->Building). Hover your mouse over the desired building and click the gear icon to see your building configuration. Once you have your buildingId, add it to integers.xml to point the sample at your building.
+
+4. For better user experience, you may want to retrieve the corresponding Latitude and Longitude values for the buildingId. The Load Building and Bluedot Location samples are using these values to initialize the camera position before loading the maps. Failing to initialize the camera will zoom out on location(0, 0). Load Building is adding these values as xml attributes to the layout where the MapFragment is used. Bluedot Location is initializing the camera location and zoom programmatically by creating a customised MapFragment (extending the provided MapFragment from the SDK). Latitude and Longitude values are added to integers.xml.
 
 After you have these keys you should be all set to run the use case samples!
 

--- a/Samples/java/src/main/java/com/phunware/java/sample/BluedotLocationActivity.java
+++ b/Samples/java/src/main/java/com/phunware/java/sample/BluedotLocationActivity.java
@@ -26,6 +26,8 @@ not be used in advertising or otherwise to promote the sale, use or
 other dealings in this Software without prior written authorization
 from Phunware, Inc. */
 
+import static com.phunware.java.sample.CustomMapFragment.getInstance;
+
 import android.content.Context;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
@@ -41,7 +43,6 @@ import com.google.android.gms.maps.model.MapStyleOptions;
 import com.phunware.core.PwCoreSession;
 import com.phunware.location.provider_managed.ManagedProviderFactory;
 import com.phunware.location.provider_managed.PwManagedLocationProvider;
-import com.phunware.mapping.MapFragment;
 import com.phunware.mapping.OnPhunwareMapReadyCallback;
 import com.phunware.mapping.PhunwareMap;
 import com.phunware.mapping.manager.Callback;
@@ -87,10 +88,11 @@ public class BluedotLocationActivity extends AppCompatActivity
 
         // Create the map manager and fragment used to load the building
         mapManager = PhunwareMapManager.create(this);
-        MapFragment mapFragment = (MapFragment) getFragmentManager().findFragmentById(R.id.map);
 
-        if (mapFragment != null) {
-            mapFragment.getPhunwareMapAsync(this);
+        if (savedInstanceState == null) {
+            getFragmentManager().beginTransaction()
+                .replace(R.id.map, getInstance(this, this))
+                .commit();
         }
     }
 

--- a/Samples/java/src/main/java/com/phunware/java/sample/CustomMapFragment.java
+++ b/Samples/java/src/main/java/com/phunware/java/sample/CustomMapFragment.java
@@ -1,0 +1,44 @@
+package com.phunware.java.sample;
+
+import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
+import android.util.TypedValue;
+import com.google.android.gms.maps.GoogleMapOptions;
+import com.google.android.gms.maps.model.CameraPosition;
+import com.google.android.gms.maps.model.CameraPosition.Builder;
+import com.google.android.gms.maps.model.LatLng;
+import com.phunware.mapping.MapFragment;
+import com.phunware.mapping.OnPhunwareMapReadyCallback;
+
+/**
+ * Example of extending {@link MapFragment} to customise
+ * the initial camera location and the zooming level of the map.
+ */
+public class CustomMapFragment extends MapFragment {
+
+    public static MapFragment getInstance(AppCompatActivity activity, OnPhunwareMapReadyCallback callback) {
+
+        TypedValue typedValue = new TypedValue();
+        activity.getResources().getValue(R.integer.building_latitude, typedValue, true);
+        double lat = typedValue.getFloat();
+        activity.getResources().getValue(R.integer.building_longitude, typedValue, true);
+        double lng = typedValue.getFloat();
+        float zoomLevel = 16f;
+
+        MapFragment mf =  new CustomMapFragment();
+        mf.getPhunwareMapAsync(callback);
+        GoogleMapOptions options = new GoogleMapOptions();
+        CameraPosition cameraOptions = new Builder()
+            .target(new LatLng(lat, lng))
+            .zoom(zoomLevel)
+            .build();
+
+        // "MapOptions" is the argument key that Google is using right now when you use their MapFragment directly.
+        // This is an implementation detail of the Google Maps library that is subject to change without notice
+        Bundle args = new Bundle();
+        args.putParcelable("MapOptions", options.camera(cameraOptions));
+
+        mf.setArguments(args);
+        return mf;
+    }
+}

--- a/Samples/java/src/main/java/com/phunware/java/sample/CustomMapFragment.java
+++ b/Samples/java/src/main/java/com/phunware/java/sample/CustomMapFragment.java
@@ -33,12 +33,14 @@ public class CustomMapFragment extends MapFragment {
             .zoom(zoomLevel)
             .build();
 
-        // "MapOptions" is the argument key that Google is using right now when you use their MapFragment directly.
-        // This is an implementation detail of the Google Maps library that is subject to change without notice
         Bundle args = new Bundle();
-        args.putParcelable("MapOptions", options.camera(cameraOptions));
+        args.putParcelable(MAP_OPTIONS_KEY, options.camera(cameraOptions));
 
         mf.setArguments(args);
         return mf;
     }
+
+    // "MapOptions" is the argument key that Google is using right now when you use their MapFragment directly.
+    // This is an implementation detail of the Google Maps library that is subject to change without notice
+    private static final String MAP_OPTIONS_KEY = "MapOptions";
 }

--- a/Samples/java/src/main/res/layout/bluedot_location.xml
+++ b/Samples/java/src/main/res/layout/bluedot_location.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    <FrameLayout
         android:id="@+id/map"
         android:name="com.phunware.mapping.MapFragment"
         android:layout_width="match_parent"

--- a/Samples/java/src/main/res/layout/load_building.xml
+++ b/Samples/java/src/main/res/layout/load_building.xml
@@ -14,7 +14,7 @@
         android:layout_height="match_parent"
         map:cameraTargetLat="@integer/building_latitude"
         map:cameraTargetLng="@integer/building_longitude"
-        map:cameraZoom="15.0" />
+        map:cameraZoom="16.0" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/Samples/java/src/main/res/layout/load_building.xml
+++ b/Samples/java/src/main/res/layout/load_building.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:map="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     tools:context="com.phunware.java.sample.LoadBuildingActivity">
 
-    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    <fragment
         android:id="@+id/map"
         android:name="com.phunware.mapping.MapFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        map:cameraTargetLat="@integer/building_latitude"
+        map:cameraTargetLng="@integer/building_longitude"
+        map:cameraZoom="15.0" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/Samples/java/src/main/res/values/integers.xml
+++ b/Samples/java/src/main/res/values/integers.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- TODO: Change this buildingId to match the building on MaaS -->
-    <integer name="buildingId">1234</integer>
+    <integer name="buildingId">12345</integer>
     <!-- TODO: Change this building Lat/Lng to match the building on MaaS -->
     <!-- Use from within an xml layout file (example building coordinates: Phunware Inc., Austin, TX) -->
     <item name="building_latitude" type="integer" format="float">30.360292</item>

--- a/Samples/java/src/main/res/values/integers.xml
+++ b/Samples/java/src/main/res/values/integers.xml
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <!-- TODO: Change this buildingId to match the building on MaaS -->
-    <integer name="buildingId">12345</integer>
+    <integer name="buildingId">1234</integer>
+    <!-- TODO: Change this building Lat/Lng to match the building on MaaS -->
+    <!-- Use from within an xml layout file (example building coordinates: Phunware Inc., Austin, TX) -->
+    <item name="building_latitude" type="integer" format="float">30.360292</item>
+    <item name="building_longitude" type="integer" format="float">-97.742193</item>
 </resources>

--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/BluedotLocationActivity.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/BluedotLocationActivity.kt
@@ -38,6 +38,7 @@ import android.widget.Spinner
 import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.MapStyleOptions
 import com.phunware.core.PwCoreSession
+import com.phunware.kotlin.sample.CustomMapFragment.Companion.newInstance
 import com.phunware.location.provider_managed.ManagedProviderFactory
 import com.phunware.location.provider_managed.PwManagedLocationProvider
 import com.phunware.mapping.MapFragment
@@ -84,8 +85,12 @@ class BluedotLocationActivity : AppCompatActivity(), OnPhunwareMapReadyCallback,
 
         // Create the map manager and fragment used to load the building
         mapManager = PhunwareMapManager.create(this)
-        mapFragment = fragmentManager.findFragmentById(R.id.map) as MapFragment
-        mapFragment.getPhunwareMapAsync(this)
+
+        if (savedInstanceState == null) {
+            fragmentManager.beginTransaction()
+                .replace(R.id.map, newInstance(this, this))
+                .commit()
+        }
     }
 
     override fun onPhunwareMapReady(phunwareMap: PhunwareMap) {

--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/CustomMapFragment.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/CustomMapFragment.kt
@@ -37,13 +37,15 @@ class CustomMapFragment : MapFragment() {
                         .target(buildingLatLng)
                         .zoom(zoomLevel)
                         .build()
-                    // "MapOptions" is the argument key that Google is using right now when you use their MapFragment directly.
-                    // This is an implementation detail of the Google Maps library that is subject to change without notice
-                    putParcelable("MapOptions", options.camera(cameraOptions))
+                    putParcelable(MAP_OPTIONS_KEY, options.camera(cameraOptions))
                 }
             }
 
         }
+
+        // "MapOptions" is the argument key that Google is using right now when you use their MapFragment directly.
+        // This is an implementation detail of the Google Maps library that is subject to change without notice
+        private const val MAP_OPTIONS_KEY = "MapOptions"
     }
 
 }

--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/CustomMapFragment.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/CustomMapFragment.kt
@@ -1,0 +1,49 @@
+package com.phunware.kotlin.sample
+
+import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
+import android.util.TypedValue
+import com.google.android.gms.maps.GoogleMapOptions
+import com.google.android.gms.maps.model.CameraPosition
+import com.google.android.gms.maps.model.LatLng
+import com.phunware.mapping.MapFragment
+import com.phunware.mapping.OnPhunwareMapReadyCallback
+
+/**
+ * Example of extending [MapFragment] to customise
+ * the initial camera location and the zooming level of the map.
+ */
+class CustomMapFragment : MapFragment() {
+
+    companion object {
+        fun newInstance(activity: AppCompatActivity, callback: OnPhunwareMapReadyCallback) : CustomMapFragment {
+
+            val buildingLatLng = TypedValue().let {
+                activity.resources.getValue(R.integer.building_latitude, it, true)
+                val buildingLat = it.float.toDouble()
+                activity.resources.getValue(R.integer.building_longitude, it, true)
+                val buildingLng = it.float.toDouble()
+                LatLng(buildingLat, buildingLng)
+            }
+
+            val zoomLevel = 16f
+
+            return CustomMapFragment().apply {
+                getPhunwareMapAsync(callback)
+                arguments = Bundle().apply {
+                    // ...
+                    val options = GoogleMapOptions()
+                    val cameraOptions = CameraPosition.Builder()
+                        .target(buildingLatLng)
+                        .zoom(zoomLevel)
+                        .build()
+                    // "MapOptions" is the argument key that Google is using right now when you use their MapFragment directly.
+                    // This is an implementation detail of the Google Maps library that is subject to change without notice
+                    putParcelable("MapOptions", options.camera(cameraOptions))
+                }
+            }
+
+        }
+    }
+
+}

--- a/Samples/kotlin/src/main/res/layout/bluedot_location.xml
+++ b/Samples/kotlin/src/main/res/layout/bluedot_location.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    <FrameLayout
         android:id="@+id/map"
         android:name="com.phunware.mapping.MapFragment"
         android:layout_width="match_parent"

--- a/Samples/kotlin/src/main/res/layout/load_building.xml
+++ b/Samples/kotlin/src/main/res/layout/load_building.xml
@@ -1,15 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:map="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context="com.phunware.java.sample.LoadBuildingActivity">
+    tools:context=".LoadBuildingActivity">
 
-    <fragment xmlns:android="http://schemas.android.com/apk/res/android"
+    <fragment
         android:id="@+id/map"
         android:name="com.phunware.mapping.MapFragment"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        map:cameraTargetLat="@integer/building_latitude"
+        map:cameraTargetLng="@integer/building_longitude"
+        map:cameraZoom="15.0" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/Samples/kotlin/src/main/res/layout/load_building.xml
+++ b/Samples/kotlin/src/main/res/layout/load_building.xml
@@ -14,7 +14,7 @@
         android:layout_height="match_parent"
         map:cameraTargetLat="@integer/building_latitude"
         map:cameraTargetLng="@integer/building_longitude"
-        map:cameraZoom="15.0" />
+        map:cameraZoom="16.0" />
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/Samples/kotlin/src/main/res/values/integers.xml
+++ b/Samples/kotlin/src/main/res/values/integers.xml
@@ -2,4 +2,8 @@
 <resources>
     <!-- TODO: Change this buildingId to match the building on MaaS -->
     <integer name="buildingId">12345</integer>
+    <!-- TODO: Change this building Lat/Lng to match the building on MaaS -->
+    <!-- Use from within an xml layout file (example building coordinates: Phunware Inc., Austin, TX) -->
+    <item name="building_latitude" type="integer" format="float">30.360292</item>
+    <item name="building_longitude" type="integer" format="float">-97.742193</item>
 </resources>


### PR DESCRIPTION
Implement initial camera location and zoom for two samples.

Load Building sample shows how to initialize camera location and zoom through xml attributes.

Bluedot Location sample shows how to initialize  camera location and zoom by extending the MapFragment and creating it programatically.

Location latitude and longitude values are set and used as integer resources. 