### PR TITLE
SWMAAS-1447 Voice Prompt icon adjustments

### DIFF
--- a/Samples/kotlin/src/main/res/layout/activity_routing.xml
+++ b/Samples/kotlin/src/main/res/layout/activity_routing.xml
@@ -29,6 +29,7 @@
         android:background="@drawable/rounded_button"
         android:contentDescription="@null"
         android:visibility="gone"
+        android:elevation="6dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/nav_overlay_container"
         app:srcCompat="@drawable/ic_muted" />
@@ -38,14 +39,14 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_below="@+id/voice"
-        android:layout_alignParentEnd="true"
-        android:layout_marginTop="8dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginTop="4dp"
         android:gravity="center"
         android:text="@string/demo_voice_prompt_muted"
+        android:textSize="12sp"
         android:textColor="#000000"
         android:visibility="gone"
-        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintEnd_toEndOf="@+id/voice"
+        app:layout_constraintStart_toStartOf="@id/voice"
         app:layout_constraintTop_toBottomOf="@+id/voice" />
 
     <LinearLayout


### PR DESCRIPTION
###### Context
Received feedback from Design with regards to Voice Prompt Icon:
> There is a shadow applied to the icon (should not be there) - the shadow should be applied to the circle container behind it.
> When 'Muted' is selected the type is right aligned. Should be centered beneath the icon
> The muted/unmuted type looks incorrect - should be roboto regular

###### Description
* Added elevation to Voice imageview of 6dp (to match default elevation of FAB)
* Unable to remove shadow from icon itself, design has approved this temporarily until they find the asset to replace it (tbd in different task)
* Refactored alignment properties in layout so that muted text's edges are constrained to icon image above, allowing for center gravity to work as intended
* Did not see at style/font being applied, adjusted textSize to match spec.
* As design does not have github accounts, have showed this to design (Ivy) on slack, who has approved.

**UI CHANGES**
![image (4)](https://user-images.githubusercontent.com/4603414/67530099-eb8b7280-f672-11e9-8fe3-c1dd99c00fa6.png)