### PR TITLE
SWMAAS-1409 Add distance to Voice Prompt Nav Instructions

### DIFF
--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/VoicePromptActivity.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/VoicePromptActivity.kt
@@ -161,6 +161,9 @@ class VoicePromptActivity : WalkTimeActivity(), TextToSpeech.OnInitListener {
     private fun getTextForPosition(navigator: Navigator, position: Int): String {
         val pair = navOverlay.getManeuverPair()
         var text = displayHelper.stringForDirection(this, pair.mainManeuver)
+        text += " ${displayHelper.distanceForDirection(this, pair.mainManeuver,
+                getString(R.string.demo_voice_prompt_prep_for))}"
+
 
         val turnManeuver = pair.turnManeuver
         var turnable = false

--- a/Samples/kotlin/src/main/res/values/strings.xml
+++ b/Samples/kotlin/src/main/res/values/strings.xml
@@ -96,6 +96,7 @@
     <string name="demo_voice_prompt_then">&#032;then&#032;</string>
     <string name="demo_voice_prompt_arrive_at_destination">&#032;to arrive at the destination.</string>
     <string name="demo_voice_prompt_preferences_key">demo_voice_prompt_preferences_key</string>
+    <string name="demo_voice_prompt_prep_for">for</string>
 
     <string name="demo_walk_time_title">Walk Time Calculations</string>
     <string name="demo_arrival_time_title">Arrival Time %1$s</string>


### PR DESCRIPTION
###### Context
Voice prompt navigation did not include distance in the audio tts. This PR leverages existing helpers to add distance to the tts string.

###### Description
* Used ManeuverDisplayHelper to retrieve a distance string for the current maneuver and concatenate with tts string.

**NO UI CHANGES**