### PR TITLE
SWMAAS-1348 Update kotlin sample colors to match design

### DIFF
--- a/Samples/java/src/main/res/values/styles.xml
+++ b/Samples/java/src/main/res/values/styles.xml
@@ -3,9 +3,9 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorPrimary">@color/taupe</item>
+        <item name="colorPrimaryDark">@color/mineShaft</item>
+        <item name="colorAccent">@color/azure</item>
     </style>
 
     <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />

--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/LocationModeManagedCompassActivity.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/LocationModeManagedCompassActivity.kt
@@ -44,6 +44,7 @@ import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.MapStyleOptions
 import com.phunware.core.PwCoreSession
 import com.phunware.core.PwLog
+import com.phunware.kotlin.sample.utils.extensions.accentColor
 import com.phunware.location.provider_managed.ManagedProviderFactory
 import com.phunware.location.provider_managed.PwManagedLocationProvider
 import com.phunware.mapping.MapFragment
@@ -223,13 +224,13 @@ class LocationModeManagedCompassActivity : AppCompatActivity(), OnPhunwareMapRea
                 locationModeFab.setImageDrawable(
                         ContextCompat.getDrawable(this, R.drawable.ic_compass))
                 locationModeFab.imageTintList = ColorStateList.valueOf(
-                        ContextCompat.getColor(this, R.color.colorAccent))
+                        ContextCompat.getColor(this, accentColor()))
             }
             mode.equals(PREF_LOCATION_LOCATE, ignoreCase = true) -> {
                 locationModeFab.setImageDrawable(
                         ContextCompat.getDrawable(this, R.drawable.ic_my_location))
                 locationModeFab.imageTintList = ColorStateList.valueOf(
-                        ContextCompat.getColor(this, R.color.colorAccent))
+                        ContextCompat.getColor(this, accentColor()))
             }
             else -> {
                 locationModeFab.setImageDrawable(

--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/LocationModesActivity.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/LocationModesActivity.kt
@@ -44,6 +44,7 @@ import com.google.android.gms.maps.CameraUpdateFactory
 import com.google.android.gms.maps.model.MapStyleOptions
 import com.phunware.core.PwCoreSession
 import com.phunware.core.PwLog
+import com.phunware.kotlin.sample.utils.extensions.accentColor
 import com.phunware.location.provider_managed.ManagedProviderFactory
 import com.phunware.location.provider_managed.PwManagedLocationProvider
 import com.phunware.mapping.MapFragment
@@ -222,13 +223,13 @@ class LocationModesActivity : AppCompatActivity(), OnPhunwareMapReadyCallback,
                 locationModeFab.setImageDrawable(
                         ContextCompat.getDrawable(this, R.drawable.ic_compass))
                 locationModeFab.imageTintList = ColorStateList.valueOf(
-                        ContextCompat.getColor(this, R.color.colorAccent))
+                        ContextCompat.getColor(this,  accentColor()))
             }
             mode.equals(PREF_LOCATION_LOCATE, ignoreCase = true) -> {
                 locationModeFab.setImageDrawable(
                         ContextCompat.getDrawable(this, R.drawable.ic_my_location))
                 locationModeFab.imageTintList = ColorStateList.valueOf(
-                        ContextCompat.getColor(this, R.color.colorAccent))
+                        ContextCompat.getColor(this,  accentColor()))
             }
             else -> {
                 locationModeFab.setImageDrawable(

--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/utils/extensions/Context.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/utils/extensions/Context.kt
@@ -1,0 +1,19 @@
+package com.phunware.kotlin.sample.utils.extensions
+
+import android.content.Context
+import android.util.TypedValue
+import com.phunware.kotlin.sample.R
+
+/**
+ * Returns the accent color as a ColorInt for the theme on the current context.
+ */
+fun Context.accentColor(): Int {
+    val typedValue = TypedValue()
+
+    val a = obtainStyledAttributes(typedValue.data, intArrayOf(R.attr.colorAccent))
+    val color = a.getColor(0, 0)
+
+    a.recycle()
+
+    return color
+}

--- a/Samples/kotlin/src/main/res/values/colors.xml
+++ b/Samples/kotlin/src/main/res/values/colors.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#3F51B5</color>
-    <color name="colorPrimaryDark">#303F9F</color>
-    <color name="colorAccent">#00BCD4</color>
+    <color name="taupe">#ff363636</color>
+    <color name="mineShaft">#2B2B2B</color>
+
     <color name="semi_transparent">#D0FFFFFF</color>
     <color name="white">#FFFFFF</color>
     <color name="inactive">#30FFFFFF</color>

--- a/Samples/kotlin/src/main/res/values/styles.xml
+++ b/Samples/kotlin/src/main/res/values/styles.xml
@@ -3,9 +3,9 @@
     <!-- Base application theme. -->
     <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
         <!-- Customize your theme here. -->
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+        <item name="colorPrimary">@color/taupe</item>
+        <item name="colorPrimaryDark">@color/mineShaft</item>
+        <item name="colorAccent">@color/azure</item>
     </style>
 
     <style name="markerIconText">


### PR DESCRIPTION
This PR updates the Kotlin sample app to match the theme colors of the design. (#suzyapproved)

**Notes**
- Best practices recommend that you have color names for the actual color used, instead of naming colors for their purpose.  (i.e `<color name="taupe">` instead of `<color name="colorPrimary">`) If you need to use a theme color (i.e. `colorPrimary`) programatically, reference it as such.
- To support the last criteria of the best practice above, I added a kt extension for Context to easily get the accent color for the theme of the current Context. (Which is used in `LocationModesActivity.kt `)

_Demo: Before and After_
![Screenshot_1572288759_Screenshot_1572288877](https://user-images.githubusercontent.com/144590/67708812-05320000-f97a-11e9-9694-1916ca8e031c.png)
