### PR TITLE
SWMAAS-1494 Remove walking time from Voice scenario

### DIFF
--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/VoicePromptActivity.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/VoicePromptActivity.kt
@@ -38,7 +38,7 @@ import com.phunware.mapping.manager.Navigator
 import com.phunware.mapping.model.RouteOptions
 import java.util.Locale
 
-class VoicePromptActivity : WalkTimeActivity(), TextToSpeech.OnInitListener {
+class VoicePromptActivity : RoutingActivity(), TextToSpeech.OnInitListener {
 
     // Voice Views
     private lateinit var voice: ImageButton


### PR DESCRIPTION
This PR removes walking arrival time from the Voice Scenario.  (extend RoutingActivity instead of extending WalkTimeActivity)

![Screenshot_1572542573_Screenshot_1572542651](https://user-images.githubusercontent.com/144590/67971151-76b3bd80-fbc9-11e9-92a9-7129e9572f18.png)
