### PR TITLE
SWMAAS-1493 Hide Voice Button when route summary is open

### DIFF
--- a/Samples/kotlin/src/main/res/layout/frag_route_summary.xml
+++ b/Samples/kotlin/src/main/res/layout/frag_route_summary.xml
@@ -2,6 +2,7 @@
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/content"
+    android:elevation="8dp"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
###### Context
Voice button is showing when Route Summary is open. This PR adds a fix to hide and display the voice button when route summary is opened and closed respectively.

###### Description
* Added elevation to RouteSummary Fragment layout to ensure it displays on top of voice icon