### PR TITLE
SWMAAS-772 Bring Walk Time Calculation to parity with iOS

### DIFF
--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/WalkTimeActivity.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/WalkTimeActivity.kt
@@ -28,10 +28,10 @@ from Phunware, Inc. */
 import android.location.Location
 import android.os.Bundle
 import android.os.Handler
-import androidx.constraintlayout.widget.ConstraintLayout
 import android.view.View
 import android.widget.Button
 import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
 import com.phunware.kotlin.sample.R
 import com.phunware.mapping.manager.Navigator
 import com.phunware.mapping.model.RouteOptions
@@ -122,24 +122,10 @@ open class WalkTimeActivity : RoutingActivity() {
             distance / averageWalkSpeed
         }
 
-        if (estimateTimeInSeconds < 60) {
-            walkTimeTextview.setText(R.string.demo_walk_time_less_than_one_minute)
-        } else {
-            val numMinutesTemp = estimateTimeInSeconds / 60.0
-            // Provide slop of 1 to 1.2 minutes where eta will be set at 1 minute and not rounded up
-            val numMinutes: Int = if (numMinutesTemp >= 1.0 && numMinutesTemp < 1.2) {
-                1
-            } else {
-                ceil(estimateTimeInSeconds / 60.0).toInt()
-            }
-            val numMinutesString: String
-            numMinutesString = if (numMinutes == 1) {
-                resources.getString(R.string.demo_walk_time_one_minute, numMinutes)
-            } else {
-                resources.getString(R.string.demo_walk_time_multiple_minutes, numMinutes)
-            }
-            walkTimeTextview.text = numMinutesString
-        }
+        val numMinutes: Int = if (estimateTimeInSeconds < 60) 1 else ceil(estimateTimeInSeconds / 60.0).toInt()
+
+        walkTimeTextview.text = resources.getQuantityString(
+                R.plurals.demo_walk_time_minutes, numMinutes, numMinutes)
 
         val calendar = Calendar.getInstance()
         calendar.add(Calendar.SECOND, estimateTimeInSeconds.toInt())

--- a/Samples/kotlin/src/main/res/values/strings.xml
+++ b/Samples/kotlin/src/main/res/values/strings.xml
@@ -106,9 +106,10 @@
     <string name="demo_arrival_time_title">Arrival Time %1$s</string>
     <string name="demo_walk_time_description">Show actual walk time</string>
     <string name="demo_walk_time_exit">Exit</string>
-    <string name="demo_walk_time_less_than_one_minute">&lt; 1 minute</string>
-    <string name="demo_walk_time_one_minute">%1$d minute</string>
-    <string name="demo_walk_time_multiple_minutes">%1$d minutes</string>
+    <plurals name="demo_walk_time_minutes">
+        <item quantity="one">%1$d minute.</item>
+        <item quantity="other">%1$d minutes.</item>
+    </plurals>
 
     <string name="demo_off_route_title">Off Route Scenario</string>
     <string name="demo_off_route_description">Shows an alert when the user goes too far off route</string>


### PR DESCRIPTION
###### Context
Android had a different more complex calculation for the walktime. This PR brings the walktime calculation to parity with iOS

###### Description
* Remove lower 20% slop range calculation for the 1m-1m59s range
* Remove logic for displaying < 1 minute and simplify to 1minute
* Added plurals and getQuantityString Format