### PR TITLE
SWMAAS-1512 handle when there are no routes available, instead of cra…

### DIFF
--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/RoutingActivity.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/RoutingActivity.kt
@@ -344,7 +344,8 @@ open class RoutingActivity : AppCompatActivity(), OnPhunwareMapReadyCallback,
      * RoutingDialogListener
      */
     override fun onGetRoutes(startId: Long, endId: Long, isAccessible: Boolean) {
-        val router: Router
+        val router: Router?
+
         if (startId.compareTo(CURRENT_LOCATION_ITEM_ID) == 0) {
             val currentLocation =
                     LatLng(mapManager.currentLocation.latitude, mapManager.currentLocation.longitude)
@@ -359,17 +360,16 @@ open class RoutingActivity : AppCompatActivity(), OnPhunwareMapReadyCallback,
             router = mapManager.findRoutes(startId, endId, isAccessible)
         }
 
-        if (router != null) {
-            val route = router.shortestRoute()
-            if (route == null) {
-                PwLog.e(TAG, "Couldn't find route.")
-                Snackbar.make(
-                        content, R.string.no_route,
-                        Snackbar.LENGTH_SHORT
-                ).show()
-            } else {
-                startNavigating(route)
-            }
+        val route: RouteOptions? = router?.shortestRoute()
+
+        if (route == null) {
+            PwLog.e(TAG, "Couldn't find route.")
+            Snackbar.make(
+                    content, R.string.no_route,
+                    Snackbar.LENGTH_SHORT
+            ).show()
+        } else {
+            startNavigating(route)
         }
     }
 


### PR DESCRIPTION
QA notices on the Route to Point of Interest Scenario, that if you attempt to navigate between two POIs where there is no route, the sample app would crash.

This was introduced in our refactor work I think (doh), because I did not treat the Router object as nullable.  PwMapManager will return a null route when `findRoutes(..)` is called if there are no routes available.

Additionally I have streamlined the logic of `RoutingActivity:onGetRoutes()` to handle the situation where the router is null to show the error snackbar.  (See demo)

_Demo: Routing to stairs with accessible turned on (no such route exists)_
![swmaas1514](https://user-images.githubusercontent.com/144590/68061184-cde88980-fcc0-11e9-92ff-60d326f53cb5.gif)
