### PR TITLE
SWMAAS-1529 clean up sharedprefs usage and default to TTS enabled.

### DIFF
--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/VoicePromptActivity.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/VoicePromptActivity.kt
@@ -48,9 +48,20 @@ class VoicePromptActivity : RoutingActivity(), TextToSpeech.OnInitListener {
 
     private var voiceListener: View.OnClickListener = View.OnClickListener { toggleVoice() }
 
-    private var voiceEnabled: Boolean = false
     private var tts: TextToSpeech? = null
     private val displayHelper: ManeuverDisplayHelper = ManeuverDisplayHelper()
+
+    private val sharedPref by lazy {
+        getSharedPreferences("lbs_sample_voice", Context.MODE_PRIVATE)
+    }
+
+    private var voiceEnabled: Boolean
+        get() {
+            return sharedPref.getBoolean(PREF_VOICE_ENABLED, true)
+        }
+        set(value) {
+            sharedPref.edit().putBoolean(PREF_VOICE_ENABLED, value).apply()
+        }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -62,9 +73,6 @@ class VoicePromptActivity : RoutingActivity(), TextToSpeech.OnInitListener {
         voice = findViewById(R.id.voice)
         voice.setOnClickListener(voiceListener)
         voiceStatusTextView = findViewById(R.id.voice_status)
-
-        val sharedPref = getPreferences(Context.MODE_PRIVATE)
-        voiceEnabled = sharedPref.getBoolean(PREF_VOICE_ENABLED, false)
     }
 
     public override fun onDestroy() {
@@ -136,7 +144,6 @@ class VoicePromptActivity : RoutingActivity(), TextToSpeech.OnInitListener {
 
     private fun toggleVoice() {
         voiceEnabled = !voiceEnabled
-        saveVoice(voiceEnabled)
         if (voiceEnabled) {
             voice.setImageResource(R.drawable.ic_unmuted)
             voiceStatusTextView.setText(R.string.demo_voice_prompt_unmuted)
@@ -149,14 +156,6 @@ class VoicePromptActivity : RoutingActivity(), TextToSpeech.OnInitListener {
             voice.setImageResource(R.drawable.ic_muted)
             voiceStatusTextView.setText(R.string.demo_voice_prompt_muted)
             tts?.stop()
-        }
-    }
-
-    private fun saveVoice(enabled: Boolean) {
-        val sharedPref = getPreferences(Context.MODE_PRIVATE) ?: return
-        with(sharedPref.edit()) {
-            putBoolean(PREF_VOICE_ENABLED, enabled)
-            apply()
         }
     }
 

--- a/Samples/kotlin/src/main/res/layout/activity_routing.xml
+++ b/Samples/kotlin/src/main/res/layout/activity_routing.xml
@@ -43,7 +43,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toBottomOf="@+id/nav_overlay"
-            app:srcCompat="@drawable/ic_muted" />
+            app:srcCompat="@drawable/ic_unmuted" />
 
         <TextView
             android:id="@+id/voice_status"
@@ -52,7 +52,7 @@
             android:layout_below="@+id/voice"
             android:layout_marginTop="4dp"
             android:gravity="center"
-            android:text="@string/demo_voice_prompt_muted"
+            android:text="@string/demo_voice_prompt_unmuted"
             android:textColor="#000000"
             android:textSize="12sp"
             android:visibility="gone"


### PR DESCRIPTION
This PR updates the Voice Routing scenario so that text-to-speech is enabled by default (instead of being disabled by default).

Additionally I cleaned up sharedpreferences usage so that code is only interacting with a computed field, isolating sharedprefs crud to a single area of code instead of spread throughout the Activity.

_Demo_
![Screenshot_1573148105_Screenshot_1573149862](https://user-images.githubusercontent.com/144590/68415088-6a3de080-0146-11ea-9c19-ced11de8f92b.png)
