### PR TITLE
SWMAAS-830 Fixed TTS not speaking when unmuting.

### DIFF
--- a/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/VoicePromptActivity.kt
+++ b/Samples/kotlin/src/main/java/com/phunware/kotlin/sample/routing/VoicePromptActivity.kt
@@ -117,6 +117,8 @@ class VoicePromptActivity : RoutingActivity(), TextToSpeech.OnInitListener {
      */
     override fun dispatchManeuverChanged(navigator: Navigator, position: Int) {
         // Play the text that is associated with the maneuver position
+        currentManeuverPosition = position
+
         if (voiceEnabled) {
             textToVoice(getTextForPosition(navigator, position))
         }

--- a/Samples/kotlin/src/main/res/values/maas_strings.xml
+++ b/Samples/kotlin/src/main/res/values/maas_strings.xml
@@ -8,5 +8,4 @@
     <string name="pw_app_id"></string>
     <string name="pw_access_key"></string>
     <string name="pw_signature_key"></string>
-    <!-- Demos -->
 </resources>


### PR DESCRIPTION
_There are no visual changes in this PR_

QA noticed that when unmuting in the Voice Prompt scenario that the current instruction was not being spoken.

It looks like when we changed VoicePromptActivity to use `dispatchManeuverChanged()` we forgot to keep track of the current maneuver position which is used to build TTS text.